### PR TITLE
fixed issue where loading indicator does not go away

### DIFF
--- a/src/components/dashboard/Browse.vue
+++ b/src/components/dashboard/Browse.vue
@@ -67,6 +67,7 @@ export default {
   },
   mounted() {
     this.$store.dispatch("fetchDatasets");
+    setTimeout(() => (this.showIndicator = false), 2000);
   }
 };
 </script>

--- a/src/components/dashboard/Manage.vue
+++ b/src/components/dashboard/Manage.vue
@@ -37,7 +37,7 @@ export default {
   watch: {
     datasets() {
       this.showIndicator = true;
-      setTimeout(() => (this.showIndicator = false), 1000);
+      setTimeout(() => (this.showIndicator = false), 2000);
     }
   },
   computed: {
@@ -47,6 +47,7 @@ export default {
   },
   mounted() {
     this.$store.dispatch("fetchUserDatasets");
+    setTimeout(() => (this.showIndicator = false), 2000);
   }
 };
 </script>

--- a/src/components/dashboard/Manage.vue
+++ b/src/components/dashboard/Manage.vue
@@ -47,7 +47,6 @@ export default {
   },
   mounted() {
     this.$store.dispatch("fetchUserDatasets");
-    setTimeout(() => (this.showIndicator = false), 2000);
   }
 };
 </script>


### PR DESCRIPTION
- fixed issue where loading indicator would not go away when there are no datasets
- still working on feature in manage tab to get a count of user datasets directly to bypass loading indicator timeout when user has no datasets